### PR TITLE
Support for test server ID via envar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ the download and upload speed and 100% packet loss in the InfluxDB. For latency 
 |-----------|---------|----------|
 | INFLUXDB_DB| speedtest | Database table to store the speed test results in. MUST be the same table name provided to the InfluxDB container. |
 | TEST_INTERVAL | 900 | Time in seconds until the speed test script is run again. Default is 15 minutes. May not be smaller than 5 minutes. |
+| SERVER_ID | | Server ID to use for tests, if not provided, server is auto-selected. |
 
 ## Contribution
 Contributions are welcome. Please follow these steps:

--- a/scripts/init_test_connection.sh
+++ b/scripts/init_test_connection.sh
@@ -12,6 +12,7 @@ do
 	# timeout and exit with 143 if speed test is not done within 300 seconds (5 minutes), no progress
 	if [ $SERVER -ne 0 ]; then
 		# if a server ID was specified, then we will use that, otherwise auto select
+		echo "Using server ID: $SERVER"
 		timeout 300 speedtest --accept-license --accept-gdpr -u Mbps -p no -s $SERVER > $FILE
 	else
 		timeout 300 speedtest --accept-license --accept-gdpr -u Mbps -p no > $FILE

--- a/scripts/init_test_connection.sh
+++ b/scripts/init_test_connection.sh
@@ -2,17 +2,24 @@
 FILE="/opt/speedtest/test_connection.log"
 INTERVAL=${TEST_INTERVAL:-900}
 DATABASE="${INFLUXDB_DB:-speedtest}"
+SERVER="${SERVER_ID:0}"
 
 while true
 do
 	TIMESTAMP=$(date "+%s")
-
-	echo "Run speedtest ..."
+	echo "Running speedtest ..."
+	
 	# timeout and exit with 143 if speed test is not done within 300 seconds (5 minutes), no progress
-	timeout 300 speedtest --accept-license --accept-gdpr -u Mbps -p no > $FILE
+	if [ $SERVER -ne 0 ]; then
+		# if a server ID was specified, then we will use that, otherwise auto select
+		timeout 300 speedtest --accept-license --accept-gdpr -u Mbps -p no -s $SERVER > $FILE
+	else
+		timeout 300 speedtest --accept-license --accept-gdpr -u Mbps -p no > $FILE
+	fi
 
 	EXIT_CODE=$?
 	echo "Speedtest exited with $EXIT_CODE"
+	
 	# if exit code of speed test command is not 0 the speed test failed and it's save to assume that no internet connection exits
 	if [ $EXIT_CODE -ne 0 ]
 	then


### PR DESCRIPTION
A list of all the server ID can be found here:
https://williamyaps.github.io/wlmjavascript/servercli.html

Specify the docker container envar `SERVER_ID` to select a specific test server to use.